### PR TITLE
feat(reconnect): add exponential backoff strategy config option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,14 @@ impl ReconnectOptions {
         self
     }
 
+    pub fn with_exp_backoff_strategy(&mut self, strategy: ExpBackoffStrategy) -> &mut Self {
+        let duration_iterator_ext = Box::new(strategy.into_iter());
+        self.inner.retries_to_attempt_fn = Arc::new(move || {
+            duration_iterator_ext.clone()
+        });
+        self
+    }
+
     pub fn build(&mut self) -> Self {
         Self {
             inner: std::mem::take(&mut self.inner),

--- a/src/strategies.rs
+++ b/src/strategies.rs
@@ -2,6 +2,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::time::Duration;
 
 /// Defines the exponential backoff strategy for retry operations.
+#[derive(Clone)]
 pub struct ExpBackoffStrategy {
     min: Duration,
     max: Option<Duration>,
@@ -68,6 +69,7 @@ impl IntoIterator for ExpBackoffStrategy {
 }
 
 /// Iterator for generating exponential backoff durations.
+#[derive(Clone)]
 pub struct ExpBackoffIter {
     strategy: ExpBackoffStrategy,
     init: f64,


### PR DESCRIPTION
Previously, as far as I could tell, there was no way to configure the backup strategy from outside the crate.
This PR adds the `with_exp_backoff_strategy` function to configure a back off strategy for `ReconnectOptions`.